### PR TITLE
UTF-8 Fix

### DIFF
--- a/lib/fcm.js
+++ b/lib/fcm.js
@@ -35,7 +35,7 @@ FCM.prototype.send = function(payload, CB) {
             'Host': self.fcmOptions.host,
             'Authorization': 'key=' + self.serverKey,
             'Content-Type': 'application/json',
-            'Content-Length': payload.length
+            'Content-Length': new Buffer(payload).length
         };
 
         self.fcmOptions.headers = headers;


### PR DESCRIPTION
Fixed the length calculation for strings with special UTF-8 characters (ie. german umlauts) which caused FCM errors.