### PR TITLE
Fixing the minimum funcionality.

### DIFF
--- a/lib/fcm.js
+++ b/lib/fcm.js
@@ -76,7 +76,7 @@ FCM.prototype.send = function(payload, CB) {
                 } else if (data.indexOf('Unauthorized') > -1) {
                     error = 'NotAuthorizedError'
                 } else {
-                    error = 'InvalidServerResponse';
+                    error = 'InvalidServerResponse ("'+ data +'")';
                 }
 
                 // Only retry if error is QuotaExceeded or DeviceQuotaExceeded

--- a/lib/fcm.js
+++ b/lib/fcm.js
@@ -19,8 +19,7 @@ function FCM(serverKey) {
         headers: {}
     };
 }
-
-module.exports = FCM;
+util.inherits(FCM, emitter);
 
 FCM.prototype.send = function(payload, CB) {
     var self = this;
@@ -103,6 +102,4 @@ FCM.prototype.send = function(payload, CB) {
     });
 };
 
-util.inherits(FCM, emitter);
-
-
+module.exports = FCM;


### PR DESCRIPTION
. . It seems that the call to "inherits" at the end replaces the ".prototype" of your class, making it non-functional. Also, it is really recommended to use the new "class <name> extends <super>", since "inherits" is now deprecated. If you don't mind, I'll make this changes to the class structure as well.