### PR TITLE
Removed asCallback log statement

### DIFF
--- a/lib/fcm.js
+++ b/lib/fcm.js
@@ -21,7 +21,6 @@ function FCM(serverKey) {
 //callback function must follow node standard (err, data) => {}
 FCM.prototype.send = function(payload, CB) {
     var self = this;
-    if (!CB) console.log("asCallback will do nothing");
 
     return new Promise(function (resolve, reject){
         var operation = retry.operation();


### PR DESCRIPTION
The asCallback log statement is quite annoying when sending lots of push notifications.